### PR TITLE
Deploy HypMinter with new init params

### DIFF
--- a/script/DeployHypMinter.s.sol
+++ b/script/DeployHypMinter.s.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {HypMinter} from "../src/contracts/HypMinter.sol";
+import {AccessManager} from "@openzeppelin/contracts/access/manager/AccessManager.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/**
+ * @title Deploy HypMinter Script
+ * @dev Script to deploy HypMinter contract with proper initialization
+ *
+ * Usage:
+ * forge script script/DeployHypMinter.s.sol:DeployHypMinter --sig "run()" --rpc-url $RPC_URL --broadcast --verify
+ *
+ * Environment Variables:
+ * - PRIVATE_KEY: Private key for deployment
+ */
+contract DeployHypMinter is Script {
+    // Constructor Constants
+    uint256 constant DISTRIBUTION_DELAY_MAXIMUM = 10 days;
+
+    // Deployment configuration => pass to initialize
+    struct DeployConfig {
+        AccessManager accessManager;
+        uint256 firstRewardTimestamp;
+        uint256 mintAllowedTimestamp;
+        uint256 distributionAllowedTimestamp;
+        uint256 distributionDelay;
+        address operatorRewardsManager;
+    }
+
+    function run() public {
+        run({
+            _accessManager: AccessManager(0x3D079E977d644c914a344Dcb5Ba54dB243Cc4863),
+            _firstRewardTimestamp: 1_752_448_487, // Sun Jul 13 2025 19:14:47 EDT
+            _mintAllowedTimestamp: 1_760_536_800, // Wednesday, October 15, 2025 10:00:00 AM GMT-04:00 DST
+            _distributionAllowedTimestamp: 1_761_141_600, // Wednesday, October 22, 2025 10:00:00 AM GMT-04:00
+            _distributionDelay: 7 days,
+            _operatorRewardsManager: 0x562Dfaac27A84be6C96273F5c9594DA1681C0DA7 // Multisig A
+        });
+    }
+
+    function run(
+        AccessManager _accessManager,
+        uint256 _firstRewardTimestamp,
+        uint256 _mintAllowedTimestamp,
+        uint256 _distributionAllowedTimestamp,
+        uint256 _distributionDelay,
+        address _operatorRewardsManager
+    ) public {
+        require(_distributionDelay <= DISTRIBUTION_DELAY_MAXIMUM, "Distribution delay too large");
+        require(_mintAllowedTimestamp > block.timestamp, "Mint allowed timestamp must be in future");
+        require(_distributionAllowedTimestamp > block.timestamp, "Distribution allowed timestamp must be in future");
+
+        DeployConfig memory config = DeployConfig({
+            firstRewardTimestamp: _firstRewardTimestamp,
+            mintAllowedTimestamp: _mintAllowedTimestamp,
+            distributionAllowedTimestamp: _distributionAllowedTimestamp,
+            distributionDelay: _distributionDelay,
+            accessManager: _accessManager,
+            operatorRewardsManager: _operatorRewardsManager
+        });
+
+        _deploy(config);
+    }
+
+    function _deploy(
+        DeployConfig memory config
+    ) internal {
+        // Start broadcast
+        address deployer = _getDeployer();
+        vm.startBroadcast(deployer);
+
+        // Deploy implementation
+        console2.log("Deploying HypMinter implementation...");
+        HypMinter implementation = new HypMinter(DISTRIBUTION_DELAY_MAXIMUM);
+        console2.log("Implementation deployed at:", address(implementation));
+
+        // Prepare initialization data
+        bytes memory initData = abi.encodeCall(
+            HypMinter.initialize,
+            (
+                AccessManager(config.accessManager),
+                config.firstRewardTimestamp,
+                config.mintAllowedTimestamp,
+                config.distributionAllowedTimestamp,
+                config.distributionDelay,
+                config.operatorRewardsManager
+            )
+        );
+
+        // Deploy proxy with deployer as proxy admin
+        console2.log("Deploying TransparentUpgradeableProxy...");
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(implementation),
+            deployer, // Use deployer as proxy admin
+            initData
+        );
+        console2.log("Proxy deployed at:", address(proxy));
+
+        // Get the proxied contract
+        HypMinter hypMinter = HypMinter(address(proxy));
+
+        vm.stopBroadcast();
+
+        // Log deployment summary
+        logDeploymentSummary(hypMinter, implementation, config);
+
+        // Verify deployment
+        verifyDeployment(hypMinter, config);
+    }
+
+    function logDeploymentSummary(HypMinter hypMinter, HypMinter implementation, DeployConfig memory config) internal {
+        console2.log("\n=== HypMinter Deployment Summary ===");
+        console2.log("Implementation:", address(implementation));
+        console2.log("Proxy (HypMinter):", address(hypMinter));
+        console2.log("Proxy Admin:", _getDeployer());
+        console2.log("Access Manager:", address(config.accessManager));
+        console2.log("");
+
+        console2.log("=== Configuration ===");
+        console2.log("First Reward Timestamp:", config.firstRewardTimestamp);
+        console2.log("Mint Allowed Timestamp:", config.mintAllowedTimestamp);
+        console2.log("Distribution Delay Maximum:", hypMinter.distributionDelayMaximum(), "seconds");
+        console2.log("Distribution Delay:", config.distributionDelay, "seconds");
+        console2.log("");
+
+        console2.log("=== Contract Constants ===");
+        console2.log("HYPER Token:", address(hypMinter.HYPER()));
+        console2.log("Rewards Contract:", address(hypMinter.REWARDS()));
+        console2.log("Symbiotic Network:", hypMinter.SYMBIOTIC_NETWORK());
+        console2.log("Mint Amount per Epoch:", hypMinter.MINT_AMOUNT() / 1e18, "HYPER");
+        console2.log("");
+
+        console2.log("=== Initial Settings ===");
+        console2.log("Operator BPS:", hypMinter.operatorBps(), "basis points");
+        console2.log("Operator Manager:", hypMinter.operatorRewardsManager());
+        console2.log("Distribution Delay:", hypMinter.distributionDelay(), "seconds");
+        console2.log("");
+
+        console2.log("=== Next Steps ===");
+        console2.log("1. Set middleware: Call networkMiddlewareService.setMiddleware(address(hypMinter))");
+        console2.log("2. Grant MINTER_ROLE: Call HYPER.grantRole(keccak256('MINTER_ROLE'), address(hypMinter))");
+        console2.log("3. Wait for mint allowed timestamp:", config.mintAllowedTimestamp);
+        console2.log("4. Start minting epochs every 30 days");
+    }
+
+    function verifyDeployment(HypMinter hypMinter, DeployConfig memory config) internal view {
+        console2.log("\n=== Deployment Verification ===");
+
+        // Verify initialization
+        require(hypMinter.lastRewardTimestamp() == config.firstRewardTimestamp, "First reward timestamp mismatch");
+        require(hypMinter.mintAllowedTimestamp() == config.mintAllowedTimestamp, "Mint allowed timestamp mismatch");
+        require(address(hypMinter.authority()) == address(config.accessManager), "Access manager mismatch");
+        require(hypMinter.distributionDelay() == config.distributionDelay, "Distribution delay mismatch");
+
+        // Verify HYPER approval
+        require(
+            hypMinter.HYPER().allowance(address(hypMinter), address(hypMinter.REWARDS())) == type(uint256).max,
+            "HYPER approval not set"
+        );
+
+        console2.log("All verifications passed!");
+    }
+
+    function _getDeployer() internal returns (address) {
+        return vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+    }
+}

--- a/src/contracts/HypMinter.sol
+++ b/src/contracts/HypMinter.sol
@@ -24,11 +24,6 @@ contract HypMinter is AccessManagedUpgradeable {
     uint256 public mintAllowedTimestamp;
 
     /**
-     * @notice Information about a reward distribution for a specific timestamp
-     * @param mintTimestamp Timestamp when the rewards were minted for this epoch
-     * @param distributed Whether the rewards have been distributed to stakers
-     */
-    /**
      * @notice Enumeration representing the distribution status of rewards for an epoch
      * @param NOT_MINTED Rewards have not been minted for this epoch yet
      * @param MINTED Rewards have been minted but not yet distributed
@@ -134,6 +129,7 @@ contract HypMinter is AccessManagedUpgradeable {
      * @param distributionDelay The new delay between reward timestamp and distribution in seconds
      */
     event DistributionDelaySet(uint256 distributionDelay);
+
     /**
      * @notice Constructor that sets the maximum distribution delay and disables initializers
      * @param _distributionDelayMaximum The maximum allowed delay between minting and distribution

--- a/src/contracts/HypMinter.sol
+++ b/src/contracts/HypMinter.sol
@@ -164,6 +164,7 @@ contract HypMinter is AccessManagedUpgradeable {
 
         // Set minting timestamps
         lastRewardTimestamp = _firstRewardTimestamp;
+        // Note that the rewards for the first epoch have already been minted
         rewardDistributions[_firstRewardTimestamp] = DistributionStatus.MINTED;
         mintAllowedTimestamp = _mintAllowedTimestamp;
         distributionDelay = _distributionDelay;

--- a/src/contracts/HypMinter.sol
+++ b/src/contracts/HypMinter.sol
@@ -43,7 +43,7 @@ contract HypMinter is AccessManagedUpgradeable {
     uint256 public distributionDelay;
 
     /// @notice Maximum delay between mint time and distribution time.
-    uint256 public immutable  distributionDelayMaximum;
+    uint256 public immutable distributionDelayMaximum;
 
     /// @notice Timestamp when distribution is allowed to begin
     uint256 public distributionAllowedTimestamp;
@@ -123,7 +123,9 @@ contract HypMinter is AccessManagedUpgradeable {
      * @dev Prevents the implementation contract from being initialized directly
      */
 
-    constructor(uint256 _distributionDelayMaximum) {
+    constructor(
+        uint256 _distributionDelayMaximum
+    ) {
         distributionDelayMaximum = _distributionDelayMaximum;
         _disableInitializers();
     }

--- a/test/HypMinter.t.sol
+++ b/test/HypMinter.t.sol
@@ -37,6 +37,7 @@ contract HypMinterTest is Test {
     AccessManager accessManager = AccessManager(0x3D079E977d644c914a344Dcb5Ba54dB243Cc4863);
     address accessManagerAdmin = 0xfA842f02439Af6d91d7D44525956F9E5e00e339f;
     address multisigB = 0xec2EdC01a2Fbade68dBcc80947F43a5B408cC3A0;
+    address multisigA = 0x562Dfaac27A84be6C96273F5c9594DA1681C0DA7;
 
     // Symbiotic network addresses
     NetworkMiddlewareService networkMiddlewareService =
@@ -72,14 +73,7 @@ contract HypMinterTest is Test {
             address(this),
             abi.encodeCall(
                 HypMinter.initialize,
-                (
-                    accessManager,
-                    firstTimestamp,
-                    mintAllowedTimestamp,
-                    mintAllowedTimestamp,
-                    6 days,
-                    0x2522d3797411Aff1d600f647F624713D53b6AA11
-                )
+                (accessManager, firstTimestamp, mintAllowedTimestamp, mintAllowedTimestamp, 6 days, multisigA)
             )
         );
         // Set hypMinter to the proxy
@@ -305,14 +299,7 @@ contract HypMinterTest is Test {
     function test_initialization_CannotReinitialize() public {
         // Try to initialize again - should revert
         vm.expectRevert();
-        hypMinter.initialize(
-            accessManager,
-            block.timestamp,
-            block.timestamp,
-            block.timestamp,
-            6 days,
-            0x2522d3797411Aff1d600f647F624713D53b6AA11
-        );
+        hypMinter.initialize(accessManager, block.timestamp, block.timestamp, block.timestamp, 6 days, multisigA);
     }
 
     function test_hyper_HasCorrectApproval() public {

--- a/test/HypMinter.t.sol
+++ b/test/HypMinter.t.sol
@@ -363,8 +363,6 @@ contract HypMinterTest is Test {
         hypMinter.setDistributionDelay(newDelay);
     }
 
-
-
     // ========== Misc Tests =========
     function test_setOperatorManager_AffectsNextMint() public {
         test_mintAndDistribute_SuccessfulDistribution();
@@ -408,7 +406,6 @@ contract HypMinterTest is Test {
         distributionStatus = hypMinter.rewardDistributions(nextEpochTimestamp);
         assertTrue(distributionStatus == HypMinter.DistributionStatus.MINTED);
     }
-
 
     // ========== Fuzz Tests ==========
 
@@ -593,7 +590,6 @@ contract HypMinterTest is Test {
             assertEq(stakingAmount, MINT_AMOUNT - operatorAmount);
         }
     }
-
 
     // ========== Gas Optimization Tests ==========
 

--- a/test/HypMinter.t.sol
+++ b/test/HypMinter.t.sol
@@ -68,7 +68,7 @@ contract HypMinterTest is Test {
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(hypMinter),
             address(this),
-            abi.encodeCall(HypMinter.initialize, (firstTimestamp, mintAllowedTimestamp, accessManager, 6 days))
+            abi.encodeCall(HypMinter.initialize, (accessManager, firstTimestamp, mintAllowedTimestamp, mintAllowedTimestamp,6 days, 0x2522d3797411Aff1d600f647F624713D53b6AA11))
         );
         // Set hypMinter to the proxy
         hypMinter = HypMinter(address(proxy));
@@ -184,13 +184,6 @@ contract HypMinterTest is Test {
         hypMinter.distributeRewards(firstTimestamp + 30 days);
     }
 
-    function test_cannotDistributeBeforeMint() public {
-        uint256 futureTimestamp = firstTimestamp + 90 days;
-        
-        vm.expectRevert("HypMinter: Rewards not minted");
-        hypMinter.distributeRewards(futureTimestamp);
-    }
-
     function test_setOperatorRewardsBps() public {
         uint256 newBps = 1500; // 15%
         vm.prank(accessManagerAdmin);
@@ -300,7 +293,7 @@ contract HypMinterTest is Test {
     function test_initialization_CannotReinitialize() public {
         // Try to initialize again - should revert
         vm.expectRevert();
-        hypMinter.initialize(block.timestamp, block.timestamp + 30 days, accessManager, 6 days);
+        hypMinter.initialize(accessManager, block.timestamp, block.timestamp, block.timestamp, 6 days, 0x2522d3797411Aff1d600f647F624713D53b6AA11);
     }
 
     function test_hyper_HasCorrectApproval() public {

--- a/test/HypMinter.t.sol
+++ b/test/HypMinter.t.sol
@@ -68,7 +68,17 @@ contract HypMinterTest is Test {
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(hypMinter),
             address(this),
-            abi.encodeCall(HypMinter.initialize, (accessManager, firstTimestamp, mintAllowedTimestamp, mintAllowedTimestamp,6 days, 0x2522d3797411Aff1d600f647F624713D53b6AA11))
+            abi.encodeCall(
+                HypMinter.initialize,
+                (
+                    accessManager,
+                    firstTimestamp,
+                    mintAllowedTimestamp,
+                    mintAllowedTimestamp,
+                    6 days,
+                    0x2522d3797411Aff1d600f647F624713D53b6AA11
+                )
+            )
         );
         // Set hypMinter to the proxy
         hypMinter = HypMinter(address(proxy));
@@ -176,9 +186,9 @@ contract HypMinterTest is Test {
         assertEq(operatorAmount + stakingAmount, MINT_AMOUNT);
     }
 
-      function test_cannotDistributeTwice() public {
+    function test_cannotDistributeTwice() public {
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Try to distribute the same epoch again
         vm.expectRevert("HypMinter: Rewards already distributed");
         hypMinter.distributeRewards(firstTimestamp + 30 days);
@@ -293,7 +303,14 @@ contract HypMinterTest is Test {
     function test_initialization_CannotReinitialize() public {
         // Try to initialize again - should revert
         vm.expectRevert();
-        hypMinter.initialize(accessManager, block.timestamp, block.timestamp, block.timestamp, 6 days, 0x2522d3797411Aff1d600f647F624713D53b6AA11);
+        hypMinter.initialize(
+            accessManager,
+            block.timestamp,
+            block.timestamp,
+            block.timestamp,
+            6 days,
+            0x2522d3797411Aff1d600f647F624713D53b6AA11
+        );
     }
 
     function test_hyper_HasCorrectApproval() public {
@@ -306,7 +323,7 @@ contract HypMinterTest is Test {
 
     function test_setDistributionDelay_Success() public {
         uint256 newDelay = 3 days;
-        
+
         vm.prank(accessManagerAdmin);
         // Expect DistributionDelaySet event to be emitted
         vm.expectEmit(true, true, true, true);
@@ -318,7 +335,7 @@ contract HypMinterTest is Test {
 
     function test_setDistributionDelay_MaxDelay() public {
         uint256 newDelay = hypMinter.distributionDelayMaximum();
-        
+
         vm.prank(accessManagerAdmin);
         vm.expectEmit(true, true, true, true);
         emit DistributionDelaySet(newDelay);
@@ -329,7 +346,7 @@ contract HypMinterTest is Test {
 
     function test_setDistributionDelay_RevertsWhenTooLarge() public {
         uint256 invalidDelay = hypMinter.distributionDelayMaximum() + 1;
-        
+
         vm.prank(accessManagerAdmin);
         vm.expectRevert("HypMinter: Distribution delay too large");
         hypMinter.setDistributionDelay(invalidDelay);
@@ -338,7 +355,7 @@ contract HypMinterTest is Test {
     function test_setDistributionDelay_RevertsWhenUnauthorized() public {
         address unauthorized = makeAddr("unauthorized");
         uint256 newDelay = 1 days;
-        
+
         vm.prank(unauthorized);
         vm.expectRevert();
         hypMinter.setDistributionDelay(newDelay);
@@ -347,41 +364,40 @@ contract HypMinterTest is Test {
     function test_setDistributionDelay_AffectsDistributionTiming() public {
         // Set up minting first
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Change distribution delay to 1 day
         uint256 newDelay = 1 days;
         vm.prank(accessManagerAdmin);
         hypMinter.setDistributionDelay(newDelay);
-        
+
         // Skip 30 days for next epoch and mint
         skip(30 days);
         hypMinter.mint();
-        
+
         // Should not be able to distribute immediately
         vm.expectRevert("HypMinter: Distribution not ready");
         hypMinter.distributeRewards(firstTimestamp + 60 days);
-        
+
         // Skip 1 day (the new delay) and should work
         skip(1 days);
         hypMinter.distributeRewards(firstTimestamp + 60 days);
     }
 
-
     function test_distributionDelay_EdgeCaseTiming() public {
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Set delay to 1 second
         vm.prank(accessManagerAdmin);
         hypMinter.setDistributionDelay(1);
-        
+
         // Next mint
         skip(30 days);
         hypMinter.mint();
-        
+
         // Should fail exactly at mint time
         vm.expectRevert("HypMinter: Distribution not ready");
         hypMinter.distributeRewards(firstTimestamp + 60 days);
-        
+
         // Should work exactly 1 second later
         skip(1);
         hypMinter.distributeRewards(firstTimestamp + 60 days);
@@ -390,46 +406,45 @@ contract HypMinterTest is Test {
     // ========== Misc Tests =========
     function test_setOperatorManager_AffectsNextMint() public {
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Change operator manager
         address newManager = makeAddr("newOperatorManager");
         vm.prank(accessManagerAdmin);
         hypMinter.setOperatorRewardsManager(newManager);
-        
+
         uint256 initialBalance = HYPER.balanceOf(newManager);
-        
+
         // Next mint should go to new manager
         skip(30 days);
         hypMinter.mint();
-        
+
         uint256 finalBalance = HYPER.balanceOf(newManager);
         uint256 expectedIncrease = hypMinter.getOperatorMintAmount();
-        
+
         assertEq(finalBalance - initialBalance, expectedIncrease);
     }
 
-
     function test_rewardDistributions_StateTracking() public {
         uint256 epochTimestamp = firstTimestamp + 30 days;
-        
+
         // Before mint - should be empty
         (uint48 mintTimestamp, bool distributed) = hypMinter.rewardDistributions(epochTimestamp);
         assertEq(mintTimestamp, 0);
         assertFalse(distributed);
-        
+
         // After setup but before our mint
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Check first epoch state
         (mintTimestamp, distributed) = hypMinter.rewardDistributions(epochTimestamp);
         assertTrue(mintTimestamp > 0);
         assertTrue(distributed);
-        
+
         // Mint next epoch
         skip(30 days);
         uint256 mintTime = vm.getBlockTimestamp();
         hypMinter.mint();
-        
+
         uint256 nextEpochTimestamp = epochTimestamp + 30 days;
         (mintTimestamp, distributed) = hypMinter.rewardDistributions(nextEpochTimestamp);
         assertEq(mintTimestamp, uint48(mintTime));
@@ -438,16 +453,16 @@ contract HypMinterTest is Test {
 
     function test_lastRewardTimestamp_Updates() public {
         uint256 initialTimestamp = hypMinter.lastRewardTimestamp();
-        
+
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         uint256 afterFirstMint = hypMinter.lastRewardTimestamp();
         assertEq(afterFirstMint, initialTimestamp + 30 days);
-        
+
         // Next mint
         skip(30 days);
         hypMinter.mint();
-        
+
         uint256 afterSecondMint = hypMinter.lastRewardTimestamp();
         assertEq(afterSecondMint, afterFirstMint + 30 days);
     }
@@ -515,10 +530,7 @@ contract HypMinterTest is Test {
 
     // ========== Advanced Fuzz Tests ==========
 
-    function testFuzz_mint_DistributeWorkflow(
-        uint256 operatorBps,
-        uint256 delayDays
-    ) public {
+    function testFuzz_mint_DistributeWorkflow(uint256 operatorBps, uint256 delayDays) public {
         // Bound inputs to valid ranges
         operatorBps = bound(operatorBps, 0, MAX_BPS - 1);
         delayDays = bound(delayDays, 0, 7);
@@ -544,10 +556,7 @@ contract HypMinterTest is Test {
 
         // Verify operator got their share immediately
         uint256 expectedOperatorAmount = (MINT_AMOUNT * operatorBps) / MAX_BPS;
-        assertEq(
-            HYPER.balanceOf(operatorManager) - operatorInitialBalance,
-            expectedOperatorAmount
-        );
+        assertEq(HYPER.balanceOf(operatorManager) - operatorInitialBalance, expectedOperatorAmount);
 
         // Try to distribute before delay - should fail if delay > 0
         if (delay > 0) {
@@ -562,10 +571,7 @@ contract HypMinterTest is Test {
 
         // Verify stakers got their share
         uint256 expectedStakingAmount = MINT_AMOUNT - expectedOperatorAmount;
-        assertEq(
-            HYPER.balanceOf(address(REWARDS)) - rewardsInitialBalance,
-            expectedStakingAmount
-        );
+        assertEq(HYPER.balanceOf(address(REWARDS)) - rewardsInitialBalance, expectedStakingAmount);
 
         // Verify total amounts add up
         assertEq(expectedOperatorAmount + expectedStakingAmount, MINT_AMOUNT);
@@ -612,9 +618,9 @@ contract HypMinterTest is Test {
 
     function test_invariant_totalSupplyIncreasesCorrectly() public {
         uint256 initialSupply = HYPER.totalSupply();
-        
+
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         uint256 afterFirstMint = HYPER.totalSupply();
         assertEq(afterFirstMint - initialSupply, MINT_AMOUNT);
 
@@ -632,10 +638,10 @@ contract HypMinterTest is Test {
         // Test invariant across different BPS values
         uint256[] memory bpsValues = new uint256[](5);
         bpsValues[0] = 0;
-        bpsValues[1] = 500;   // 5%
-        bpsValues[2] = 1000;  // 10%
-        bpsValues[3] = 5000;  // 50%
-        bpsValues[4] = 10000 - 1; // 100%
+        bpsValues[1] = 500; // 5%
+        bpsValues[2] = 1000; // 10%
+        bpsValues[3] = 5000; // 50%
+        bpsValues[4] = 10_000 - 1; // 100%
 
         for (uint256 i = 0; i < bpsValues.length; i++) {
             vm.prank(accessManagerAdmin);
@@ -646,7 +652,7 @@ contract HypMinterTest is Test {
 
             // Invariant: operator + staking = total
             assertEq(operatorAmount + stakingAmount, MINT_AMOUNT);
-            
+
             // Verify calculations
             assertEq(operatorAmount, (MINT_AMOUNT * bpsValues[i]) / MAX_BPS);
             assertEq(stakingAmount, MINT_AMOUNT - operatorAmount);
@@ -655,7 +661,7 @@ contract HypMinterTest is Test {
 
     function test_invariant_cannotDistributeInFuture() public {
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Try various future timestamps
         uint256[] memory futureOffsets = new uint256[](4);
         futureOffsets[0] = 60 days;
@@ -674,26 +680,26 @@ contract HypMinterTest is Test {
 
     function test_gas_multipleOperations() public {
         test_mintAndDistribute_SuccessfulDistribution();
-        
+
         // Measure gas for subsequent operations
         uint256 gasBefore = gasleft();
-        
+
         skip(30 days);
         hypMinter.mint();
-        
+
         uint256 gasAfterMint = gasleft();
         uint256 mintGas = gasBefore - gasAfterMint;
-        
+
         skip(distributionDelay);
         hypMinter.distributeRewards(firstTimestamp + 60 days);
-        
+
         uint256 gasAfterDistribute = gasleft();
         uint256 distributeGas = gasAfterMint - gasAfterDistribute;
-        
+
         // Log gas usage for analysis
         console2.log("Mint gas used:", mintGas);
         console2.log("Distribute gas used:", distributeGas);
-        
+
         // Basic assertions that operations didn't use excessive gas
         assertTrue(mintGas < 500_000, "Mint used too much gas");
         assertTrue(distributeGas < 500_000, "Distribute used too much gas");


### PR DESCRIPTION
See `run()`.

Simulated deployment below:
```shell
➜  rewards git:(deploy-hyp-minter-v2) PRIVATE_KEY=$(hypkey) forge script script/DeployHypMinter.s.sol:DeployHypMinter \
--sig "run()" \
--rpc-url mainnet
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
[⠊] Compiling...
No files changed, compilation skipped
Warning: Detected artifacts built from source files that no longer exist. Run `forge clean` to make sure builds are in sync with project files.
 - /Users/tosinalabi/rewards/test/MinterDeploy.t.sol
Script ran successfully.

== Logs ==
  Deploying HypMinter implementation...
  Implementation deployed at: 0x027eCd98e9C0c85cF51A85fc2b359Fd9aEF93623
  Deploying TransparentUpgradeableProxy...
  Proxy deployed at: 0xAa3Ec3b874bd262C25D8e0b6b7FF62E2E4cbd7E1
  
=== Deployment Verification ===
  All verifications passed!

## Setting up 1 EVM.

==========================

Chain 1

Estimated gas price: 2.018724544 gwei

Estimated total gas used for script: 2445569

Estimated amount required: 0.004936930164345536 ETH

==========================

SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet configuration(s) to the previous command. See forge script --help for more.

Transactions saved to: /Users/tosinalabi/rewards/broadcast/DeployHypMinter.s.sol/1/dry-run/run-latest.json

Sensitive values saved to: /Users/tosinalabi/rewards/cache/DeployHypMinter.s.sol/1/dry-run/run-latest.json
```