### PR TITLE
fix: Audit remediation (store staking amounts)

### DIFF
--- a/src/contracts/HypMinter.sol
+++ b/src/contracts/HypMinter.sol
@@ -100,6 +100,8 @@ contract HypMinter is AccessManagedUpgradeable {
      */
     uint256 public operatorBps;
 
+    mapping(uint rewardTimestamp => uint stakingAmount) public stakingAmounts;
+
     /**
      * @notice Emitted when HYPER tokens are minted for an epoch
      * @dev Indicates successful minting of MINT_AMOUNT tokens to the contract
@@ -169,10 +171,12 @@ contract HypMinter is AccessManagedUpgradeable {
         mintAllowedTimestamp = _mintAllowedTimestamp;
         distributionDelay = _distributionDelay;
         distributionAllowedTimestamp = _distributionAllowedTimestamp;
-
+        
         // Initialize operator rewards settings with default values
         operatorRewardsManager = _operatorRewardsManager;
         operatorBps = 1000;
+        stakingAmounts[_firstRewardTimestamp] = getStakingMintAmount();
+
 
         // Approve maximum HYPER tokens for rewards distribution to avoid future approval calls
         HYPER.approve(address(REWARDS), type(uint256).max);
@@ -192,11 +196,14 @@ contract HypMinter is AccessManagedUpgradeable {
         // Update the last mint timestamp for next epoch calculation
         rewardDistributions[newTimestamp] = DistributionStatus.MINTED;
         lastRewardTimestamp = newTimestamp;
+        uint operatorAmount = getOperatorMintAmount();
+        // Because operator bps are mutable, take note of the staking/operator amounts at the time of minting
+        stakingAmounts[newTimestamp] = MINT_AMOUNT - operatorAmount;
 
         // Mint the full amount to this contract
         HYPER.mint(address(this), MINT_AMOUNT);
         // Transfer operator rewards to operator rewards manager
-        HYPER.transfer(operatorRewardsManager, getOperatorMintAmount());
+        HYPER.transfer(operatorRewardsManager, operatorAmount);
 
         emit Mint();
     }
@@ -230,7 +237,7 @@ contract HypMinter is AccessManagedUpgradeable {
         REWARDS.distributeRewards({
             network: SYMBIOTIC_NETWORK,
             token: address(HYPER),
-            amount: getStakingMintAmount(),
+            amount: stakingAmounts[rewardTimestamp], // Use stored staking amount for this epoch
             data: abi.encode(rewardTimestamp, type(uint256).max, bytes(""), bytes(""))
         });
         emit Distribution(operatorBps);

--- a/src/contracts/HypMinter.sol
+++ b/src/contracts/HypMinter.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {AccessManagedUpgradeable} from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import {
+    AccessManagedUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 import {AccessManager} from "@openzeppelin/contracts/access/manager/AccessManager.sol";
 
 import {IDefaultStakerRewards} from "../interfaces/defaultStakerRewards/IDefaultStakerRewards.sol";
@@ -100,13 +102,17 @@ contract HypMinter is AccessManagedUpgradeable {
      */
     uint256 public operatorBps;
 
-    mapping(uint rewardTimestamp => uint stakingAmount) public stakingAmounts;
+    /**
+     * @notice Mapping to store staking amounts for each reward timestamp
+     * @dev Captures the exact staking amount at mint time to handle mutable operator BPS
+     */
+    mapping(uint256 rewardTimestamp => uint256 stakingAmount) public stakingAmounts;
 
     /**
      * @notice Emitted when HYPER tokens are minted for an epoch
      * @dev Indicates successful minting of MINT_AMOUNT tokens to the contract
      */
-    event Mint(uint rewardTimestamp);
+    event Mint(uint256 rewardTimestamp);
 
     /**
      * @notice Emitted when rewards are distributed to stakers
@@ -171,12 +177,11 @@ contract HypMinter is AccessManagedUpgradeable {
         mintAllowedTimestamp = _mintAllowedTimestamp;
         distributionDelay = _distributionDelay;
         distributionAllowedTimestamp = _distributionAllowedTimestamp;
-        
+
         // Initialize operator rewards settings with default values
         operatorRewardsManager = _operatorRewardsManager;
         operatorBps = 1000;
         stakingAmounts[_firstRewardTimestamp] = getStakingMintAmount();
-
 
         // Approve maximum HYPER tokens for rewards distribution to avoid future approval calls
         HYPER.approve(address(REWARDS), type(uint256).max);
@@ -196,7 +201,7 @@ contract HypMinter is AccessManagedUpgradeable {
         // Update the last mint timestamp for next epoch calculation
         rewardDistributions[newTimestamp] = DistributionStatus.MINTED;
         lastRewardTimestamp = newTimestamp;
-        uint operatorAmount = getOperatorMintAmount();
+        uint256 operatorAmount = getOperatorMintAmount();
         // Because operator bps are mutable, take note of the staking/operator amounts at the time of minting
         stakingAmounts[newTimestamp] = MINT_AMOUNT - operatorAmount;
 

--- a/src/contracts/HypMinter.sol
+++ b/src/contracts/HypMinter.sol
@@ -106,7 +106,7 @@ contract HypMinter is AccessManagedUpgradeable {
      * @notice Emitted when HYPER tokens are minted for an epoch
      * @dev Indicates successful minting of MINT_AMOUNT tokens to the contract
      */
-    event Mint();
+    event Mint(uint rewardTimestamp);
 
     /**
      * @notice Emitted when rewards are distributed to stakers
@@ -205,7 +205,7 @@ contract HypMinter is AccessManagedUpgradeable {
         // Transfer operator rewards to operator rewards manager
         HYPER.transfer(operatorRewardsManager, operatorAmount);
 
-        emit Mint();
+        emit Mint(newTimestamp);
     }
 
     /**

--- a/test/HypMinter.t.sol
+++ b/test/HypMinter.t.sol
@@ -120,7 +120,7 @@ contract HypMinterTest is Test {
 
         // Expect Mint event to be emitted
         vm.expectEmit(true, true, true, true);
-        emit HypMinter.Mint();
+        emit HypMinter.Mint(firstTimestamp + 30 days);
         hypMinter.mint();
         assertEq(
             HYPER.balanceOf(hypMinter.operatorRewardsManager()) - initialOperatorBalance,


### PR DESCRIPTION
# Description
See https://gist.github.com/this-is-chainlight/1ee79a81370d157c557801db41805dc4 for details.
Fixes ENG-2260
https://linear.app/hyperlane-xyz/issue/ENG-2260/remediate-hypminter-audit
 # Summary

  - Add reward timestamp tracking to mint events for better auditability
  - Store staking amounts at mint time to handle mutable operator BPS

  # Changes

  - Event Enhancement: Updated Mint event to include reward timestamp parameter for tracking when rewards were minted
  - Staking Amount Storage: Added stakingAmounts mapping to store the exact staking amount calculated at mint time, preventing issues when operator BPS changes between mint and distribution
  - Operator Amount Calculation: Store operator amount at mint time to ensure consistent reward distribution even if operator BPS is modified later

  # Test Updates

  - Updated mint event expectation in tests to include the new timestamp parameter